### PR TITLE
fix: 修复 Star History 图表失效

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ docker compose -f docker/docker-compose.yml up -d
 
 <div align="center">
 
-[![Star History](https://api.star-history.com/svg?repos=FatPaper-1874/mine-monopoly&type=Date)](https://star-history.com/#FatPaper-1874/mine-monopoly&Date)
+[![Star History](https://star-history.dera.page/svg?repos=FatPaper-1874/mine-monopoly&type=Date)](https://star-history.dera.page/#FatPaper-1874/mine-monopoly&Date)
 
 </div>
 


### PR DESCRIPTION
当前 README 中的 Star History 图表由于 GitHub stargazer API 限制已无法正常显示。本 PR 将其迁移至可用的镜像地址 star-history.dera.page，该地址使用无需 API token 的数据源，使星标历史图表恢复可用。